### PR TITLE
tips on how to use `routes` in `now.json`

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,8 +7,8 @@
   "routes": [
     { "src": "/", "dest": "/" },
     { "src": "/redirect", "dest": "/redirect" },
-    { "src": "/(.*)", "dest": "/movie/$1" },
-    { "src": "/(.*)/play", "dest": "/play/$1" },
+    { "src": "/(?<movie>[^/]*)", "dest": "/movie/$movie" },
+    { "src": "/(?<movie>[^/]*)/play", "dest": "/play/$movie" },
     { "src": "/_next/static/(?:[^/]+/pages|chunks|runtime)/.+", "headers": { "cache-control": "immutable,max-age=31536000" } }
   ],
   "build": {


### PR DESCRIPTION
this should solve your _next/static 404 errors but you still need to figure out the actual dest to send your movie routes to.

read https://zeit.co/docs/v2/deployments/routes/ for details.